### PR TITLE
limit the number of parts before creating a multi-part zip

### DIFF
--- a/app/src/main/java/com/wirelessalien/zipxtract/fragment/MainFragment.kt
+++ b/app/src/main/java/com/wirelessalien/zipxtract/fragment/MainFragment.kt
@@ -1528,13 +1528,23 @@ class MainFragment : Fragment(), FileAdapter.OnItemClickListener, FileAdapter.On
         ContextCompat.startForegroundService(requireContext(), intent)
     }
 
-    fun convertToBytes(size: Long?, unit: String): Long? {
-        return size?.times(when (unit) {
+    fun convertToBytes(size: Long, unit: String): Long {
+        return size.times(when (unit) {
             "KB" -> 1024L
             "MB" -> 1024L * 1024
             "GB" -> 1024L * 1024 * 1024
             else -> 1024L
         })
+    }
+
+    /** Returns the number of parts (rounded up) */
+    fun getMultiZipPartsCount(selectedFilesSize: Long, splitZipSize: Long): Long {
+        if (splitZipSize <= 0) {
+            return Long.MAX_VALUE
+        }
+        val division = selectedFilesSize / splitZipSize
+        val remainder = selectedFilesSize % splitZipSize
+        return if (remainder > 0) division + 1 else division
     }
 
     fun startSevenZService(password: String?, archiveName: String, compressionLevel: Int, solid: Boolean, threadCount: Int, filesToArchive: List<String>) {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -120,4 +120,5 @@
     <string name="confirm_password">Confirmer mot de passe</string>
     <string name="passwords_do_not_match">Mot de passe ne correspond pas</string>
     <string name="wrong_password">Mot de passe faux</string>
+    <string name="error_too_many_parts">Le découpage générerait %1$d parties (maximum autorisé : %2$d)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
     <string name="confirm_password">Confirm Password</string>
     <string name="passwords_do_not_match">Password do not match</string>
     <string name="wrong_password">Wrong password</string>
+    <string name="error_too_many_parts">The cutting would generate %1$d parts (maximum allowed: %2$d)</string>
     <string name="file_already_exists">File already exists</string>
     <string name="select_archive_type_title">Select archive type</string>
 


### PR DESCRIPTION
Added asynchronous validation of the number of parts before launching the split ZIP service, with an error displayed directly on the input field. This check (max. 100 files for example) prevents an incorrect unit or value entered from generating too many files, which can make exploring the folder impossible on a mobile device and degrade the user experience.