### PR TITLE
Document that extracted file timestamps follow archive timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ZipXtract is a fully open-source Android application designed for comprehensive 
 *   **Encrypted Archives:** Handles password-protected ZIP and 7z files.
 *   **Multi-Volume Archives:** Seamlessly extracts multi-volume RAR and 7z archives.
 *   **Split Archives:** Support for extracting split ZIP files.
+*   **File timestamps:** Extracted file timestamps match what was stored in the archive file.
 
 ### Flexible Archive Creation
 *   **Popular Formats:** Create ZIP, 7z and TAR archives (with multiple type of compression support).


### PR DESCRIPTION
The standard AOSP "Files" app can zip and unzip files, but extracted files end up with the modification time of the extraction, not the modification time that was stored in the ZIP.

I built and used ZipXtract in the hope that it would correctly set timestamps on extracted files, and it appears to do that correctly at least in the case of ZIP (I did not test RAR, 7z, etc.).  If this feature works for all archive formats, documenting it in the README might encourage more people to use ZipXtract.